### PR TITLE
Fix: Static Closure Parameter Hints Position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1287,6 +1288,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1551,6 +1553,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2048,6 +2051,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4400,6 +4404,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4976,6 +4981,7 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -5025,6 +5031,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -5323,6 +5330,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -6193,7 +6201,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -6368,6 +6377,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
       "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -6715,6 +6725,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8362,6 +8373,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
           "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -8781,6 +8793,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -8814,6 +8827,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/src/parser.js
+++ b/src/parser.js
@@ -94,7 +94,6 @@ class Parser {
         startLoc = {
           ...startLoc,
           column: startLoc.column - 7, // "static " is 7 characters
-          offset: startLoc.offset - 7,
         };
       }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -86,9 +86,17 @@ class Parser {
         argument = argument.left;
       }
 
-      const startLoc = argument.loc.start;
+      let startLoc = argument.loc.start;
       const endLoc = argument.loc.end;
       let argKind = argument.kind || '';
+
+      if ((argument.kind === 'arrowfunc' || argument.kind === 'closure') && argument.isStatic) {
+        startLoc = {
+          ...startLoc,
+          column: startLoc.column - 7, // "static " is 7 characters
+          offset: startLoc.offset - 7,
+        };
+      }
 
       if (
         argument.kind &&

--- a/src/parser.spec.js
+++ b/src/parser.spec.js
@@ -257,4 +257,42 @@ describe('Parser', () => {
     expect(functionGroups).to.have.lengthOf(2);
     expect(functionGroups).to.deep.equal(expectedFunctionGroups);
   });
+
+  it('should correctly parse static closures and arrow functions', () => {
+    const text = `<?php
+    class Test {
+        public function someMethod($callback) {
+            return $callback();
+        }
+
+        public function test() {
+            // Regular arrow function
+            $this->someMethod(fn () => true);
+
+            // Static arrow function
+            $this->someMethod(static fn () => true);
+
+            // Regular closure
+            $this->someMethod(function () { return true; });
+
+            // Static closure
+            $this->someMethod(static function () { return true; });
+        }
+    }
+    `;
+    parser.parse(text);
+    const { functionGroups } = parser;
+
+    expect(functionGroups).to.have.lengthOf(4);
+
+    expect(functionGroups[0].args[0].start.character).to.equal(30);
+    expect(functionGroups[1].args[0].start.character).to.equal(30);
+    expect(functionGroups[2].args[0].start.character).to.equal(30);
+    expect(functionGroups[3].args[0].start.character).to.equal(30);
+
+    expect(functionGroups[0].args[0].kind).to.equal('arrowfunc');
+    expect(functionGroups[1].args[0].kind).to.equal('arrowfunc');
+    expect(functionGroups[2].args[0].kind).to.equal('closure');
+    expect(functionGroups[3].args[0].kind).to.equal('closure');
+  });
 });

--- a/test/examples/general.php
+++ b/test/examples/general.php
@@ -12,3 +12,11 @@ function add(int...$vars) {
 
 echo join(', ', [1, 2, 3]);
 echo add(1, 2, 3);
+
+function testClosure(callable $callback): void {
+    $callback();
+}
+
+testClosure(static function (): void {
+    echo "Hello!";
+});


### PR DESCRIPTION
# Fix: Static Closure Parameter Hints Position

## Problem

Parameter hints for static closures were incorrectly positioned between `static` and `fn` (or `function`) keywords

```php
$this->someMethod(static /**callback:**/ fn () => true);
```

## Solution

Modified the parser to adjust the starting position for static closures and arrow functions, placing hints before the `static` keyword

```php
$this->someMethod(/**callback:**/ static fn () => true);
```

## Changes

- Updated `src/parser.js` to detect static closures (`isStatic` flag) and adjust position
- Added unit test in `src/parser.spec.js`